### PR TITLE
Fix process creation

### DIFF
--- a/lycheepy/configuration/configuration/serializers/process.py
+++ b/lycheepy/configuration/configuration/serializers/process.py
@@ -26,6 +26,7 @@ class ProcessSerializer(Serializer):
         return super(ProcessSerializer, self).update(identifier, data)
 
     def deserialize(self, data, instance):
+        instance.id = None
         instance.identifier = data.get('identifier', instance.identifier)
         instance.title = data.get('title', instance.title)
         instance.abstract = data.get('abstract', instance.abstract)


### PR DESCRIPTION
Fix process creation through the Configuration API. It was failing because of changes on the ORM and pycopg2.